### PR TITLE
Refactors docgen_cli

### DIFF
--- a/docgen_cli.py
+++ b/docgen_cli.py
@@ -42,8 +42,8 @@ def markdown_render(command: str, output_dir: str, output_file: str) -> str:
     the commands nested in it.
 
     Args:
-        command (str): The command that is executed as `wandb command --help`
-        output_file (str): The file in which the markdown is written.
+        command: (str) The command that is executed as `wandb command --help`
+        output_file: (str) The file in which the markdown is written.
 
     Returns:
         str: The output directory

--- a/docgen_cli.py
+++ b/docgen_cli.py
@@ -3,27 +3,86 @@ import re
 import subprocess
 from typing import Tuple
 
-#                      (             - Start of capture
-#                       .*?          - 0 or more repitions of any character except a new line (non-greedy)
-#                          \w        - Not a word character
-#                            )       - End of capture
-#                              +     - 1 or more repitions of space
-#                               (    - Start of capture
-#                                .*  - 0 of more repitions of any character except a new line
-#                                  ) - End of group
 PATTERN = re.compile(r"(.*?\w) +(.*)")
+# (           - Start of capture
+#  .*?        - 0 or more repetitions of any character except a new line (non-greedy)
+#   \w        - Not a word character
+#      )      - End of capture
+#       +     - 1 or more repetitions of space
+#        (    - Start of capture
+#         .*  - 0 of more repetitions of any character except a new line
+#           ) - End of group
+
 KEYWORDS = ["Options:", "Commands:"]
-TEMPLATE = """
-# {}
+TEMPLATE = "# {}\n\n{}\n\n{}\n\n{}\n\n{}"
 
-{}
 
-{}
+def build(output_dir: str = None):
+    """
+    Entry point for docgen_cli.
 
-{}
+    Builds the entire documentation for `wandb` CLI
+    by calling wandb --help, parsing the output,
+    and then doing the same for each subcommand.
 
-{}
-""".strip()
+    Args:
+        output_dir: (str) The output directory for the generated CLI docs.
+    """
+    if output_dir is None:
+        output_dir = os.getcwd()
+
+    output_dir, output_file = prepare_dirs(output_dir, "cli")
+
+    markdown_render("wandb", output_dir, output_file)
+
+
+def markdown_render(command: str, output_dir: str, output_file: str) -> str:
+    """
+    Renders the markdown and also provides
+    the commands nested in it.
+
+    Args:
+        command (str): The command that is executed as `wandb command --help`
+        output_file (str): The file in which the markdown is written.
+
+    Returns:
+        str: The output directory
+    """
+    usage, summary, parsed_dict = parse_help(command)
+    if usage:
+        # Document usage
+        usage = usage.split(":")
+        usage = f"**Usage**\n\n`{usage[1]}`"
+    if summary:
+        # Document summary
+        summary = f"**Summary**\n{summary}"
+
+    if "Options:" in parsed_dict.keys():
+        options = get_options_markdown(parsed_dict["Options:"])
+    else:
+        options = ""
+
+    if "Commands:" in parsed_dict.keys():
+        subcommands, subcommand_list = get_subcommands_markdown(command, parsed_dict["Commands:"])
+    else:
+        subcommands, subcommand_list = "", []
+
+    # Write to the output file
+    if usage or summary or options or subcommands:
+        write_to_file(output_file, command, usage, summary, options, subcommands)
+
+    # render markdown for subcommands
+    if len(subcommand_list) > 0:
+        for command in subcommand_list:
+            # For `command --help`
+            command_dir_name = "-".join(command.split(" "))
+            output_dir, output_file = prepare_dirs(output_dir, command_dir_name)
+
+            output_dir = markdown_render(command, output_dir, output_file)
+
+    parent_path = os.path.dirname(output_dir)
+
+    return parent_path
 
 
 def run_help(command: str) -> str:
@@ -98,114 +157,71 @@ def parse_help(command: str) -> Tuple[str, str, str]:
         return usage, summary, parsed_dict
 
 
-def markdown_render(command: str, output_dir: str, output_file: str) -> str:
+def get_options_markdown(options):
+    """Formats the options of a command as a markdown table.
     """
-    Renders the markdown and also provides
-    the commands nested in it.
+    options_md = ""
 
-    Args:
-        command (str): The command that is executed `wandb command --help`
-        output_file (str): The file in which the markdown is written.
+    for element in options:
+        description = parse_description(element)
 
-    Returns:
-        str: The output directory
-    """
-    usage, summary, parsed_dict = parse_help(command)
-    if usage:
-        # Document usage
-        usage = usage.split(":")
-        usage = f"**Usage**\n\n`{usage[1]}`"
-    if summary:
-        # Document summary
-        summary = f"**Summary**\n{summary}"
-    options = ""
-    if "Options:" in parsed_dict.keys():
-        # Document options
-        for element in parsed_dict.get("Options:"):
-            des = (
-                " ".join(list(filter(lambda x: x, element[1].split(" ")[1:])))
-                if element[1]
-                .split(" ")[0]
-                .isupper()  # to check for types in help page eg. --version INTEGER the version
-                else element[1]
-            )
-            # concatenate all the options
-            options += f"""|{element[0]}|{des}|\n"""
-        options = (
-            """**Options**\n| **Options** | **Description** |\n|:--|:--|:--|\n"""
-            + options
-        )
+        # concatenate all the options
+        options_md += f"""|{element[0]}|{description}|\n"""
 
-    commands = ""
-    command_list = []
-    if "Commands:" in parsed_dict.keys():
-        # Document commands
-        for element in parsed_dict.get("Commands:"):
-            command_list.append(
-                f"{command} {element[0]}"
-            )  # Keeping a list of all the nested counts
-            des = (
-                " ".join(list(filter(lambda x: x, element[1].split(" ")[1:])))
-                if element[1]
-                .split(" ")[0]
-                .isupper()  # to check for types in help page eg. --version INTEGER the version
-                else element[1]
-            )
-            # concatenate all the options
-            commands += f"""|{element[0]}|{des}|\n"""
-        commands = (
-            """**Commands**\n| **Commands** | **Description** |\n|:--|:--|:--|\n"""
-            + commands
-        )
-
-    # Write to the output file
-    if usage or summary or options or commands:
-        with open(output_file, "w") as fp:
-            fp.write(
-                TEMPLATE.format(
-                    command,  # Heading
-                    usage,  # Usage
-                    summary,  # Summary
-                    options,  # Options
-                    commands,  # Commands
-                )
-            )
-
-    if len(command_list) > 0:
-        for command in command_list:
-            # For `command --help`
-            command_file_name = "-".join(command.split(" "))
-            output_dir = os.path.join(output_dir, f"{command_file_name}")
-            os.mkdir(path=output_dir)
-            output_file = os.path.join(output_dir, "README.md")
-            output_dir = markdown_render(
-                command=command, output_dir=output_dir, output_file=output_file
-            )
-
-    else:
-        # BASE CONDITION TO STOP RECURSION
-        parent_path = os.path.dirname(output_dir)
-        return parent_path
-    # Return the parent directory
-    parent_path = os.path.dirname(output_dir)
-    return parent_path
-
-
-def build(output_dir: str = None):
-    """
-    Entry point for docgen_cli.
-    Builds the entire documentation for `wandb` CLI.
-
-    Args:
-        output_dir: (str) The output directory for the generated CLI docs.
-    """
-    if output_dir is None:
-        output_dir = os.getcwd()
-
-    # For `wandb --help`
-    output_dir = os.path.join(output_dir, "cli")
-    os.mkdir(path=output_dir)
-    output_file = os.path.join(output_dir, "README.md")
-    output_dir = markdown_render(
-        command="wandb", output_dir=output_dir, output_file=output_file
+    options_md = (
+        """**Options**\n| **Options** | **Description** |\n|:--|:--|:--|\n"""
+        + options_md
     )
+    return options_md
+
+
+def get_subcommands_markdown(command, subcommands):
+    """Formats the subcommands of a command as a markdown table.
+    """
+    subcommands_md, subcommand_list = "", []
+
+    for element in subcommands:
+        subcommand_list.append(
+            f"{command} {element[0]}"
+        )  # Keeping a list of all the nested counts
+        description = parse_description(element)
+        # concatenate all the options
+        subcommands_md += f"""|{element[0]}|{description}|\n"""
+    subcommands_md = (
+        """**Commands**\n| **Commands** | **Description** |\n|:--|:--|:--|\n"""
+        + subcommands_md
+    )
+
+    return subcommands_md, subcommand_list
+
+
+def parse_description(element):
+
+    markdown = (
+        " ".join(list(filter(lambda x: x, element[1].split(" ")[1:])))
+        if element[1]
+        .split(" ")[0]
+        .isupper()  # to check for types in help page eg. --version INTEGER the version
+        else element[1]
+    )
+
+    return markdown
+
+
+def write_to_file(output_file, command, usage, summary, options, subcommands):
+    """Write contents to the output_file based on TEMPLATE"""
+
+    contents = TEMPLATE.format(command, usage, summary, options, subcommands)
+    with open(output_file, "w") as fp:
+        fp.write(contents)
+
+
+def prepare_dirs(base_dir, subdir_name):
+    """Add a subdirectory with README to a base directory.
+
+    Returns the directory and README paths.
+    """
+    subdir = os.path.join(base_dir, subdir_name)
+    os.mkdir(path=subdir)
+    markdown_file = os.path.join(subdir, "README.md")
+    return subdir, markdown_file

--- a/docgen_lib.py
+++ b/docgen_lib.py
@@ -6,32 +6,16 @@ import wandb
 
 DIRNAME = "library"
 
+# fmt: off
 # which datatypes are we documenting?
-WANDB_DATATYPES = [
-    "Graph",
-    "Image",
-    "Plotly",
-    "Video",
-    "Audio",
-    "Table",
-    "Html",
-    "Object3D",
-    "Molecule",
-    "Histogram",
-]
+WANDB_DATATYPES = ["Graph", "Image", "Plotly", "Video",
+                   "Audio", "Table", "Html", "Object3D",
+                   "Molecule", "Histogram",]
 
 # which parts of the API are we documenting?
-WANDB_API = [
-    "Api",
-    "Projects",
-    "Project",
-    "Runs",
-    "Run",
-    "Sweep",
-    "Files",
-    "File",
-    "Artifact",
-]
+WANDB_API = ["Api", "Projects", "Project", "Runs", "Run",
+             "Sweep", "Files", "File", "Artifact",]
+# fmt: on
 
 
 def build(git_hash, code_url_prefix, output_dir):

--- a/generate.py
+++ b/generate.py
@@ -19,6 +19,7 @@ def main(args):
     output_dir = args.output_dir
     code_url_prefix = "/".join([args.repo, "tree", f"{git_hash}", args.prefix])
 
+    # Create the library docs
     docgen_lib.build(git_hash, code_url_prefix, output_dir)
 
     # convert generate_lib output to GitBook format


### PR DESCRIPTION
The diff is ugly because I changed the `TEMPLATE` variable to a single line, which confuses git, but this PR is a refactor of `docgen_cli` (and in particular `markdown_render`) to make it easier to read.

- New functions:
  - `get_options_markdown`, `get_subcommands_markdown`: encapsulates the handling of the options and sub-command markdown table generation, so they don't take up space in `markdown_render`
  - `parse_description`: encapsulates the gnarly filter-lambda that's used for options and sub-commands.
  - `write_to_file`: encapsulates the filling of `TEMPLATE` plus writing to file
  - `prepare_dirs`: encapsulates the logic of "add a subdirectory that has a README.md" that gets used in `build` and in the `markdown_render` recursion loop.
- Formatting changes
  - Reduces horizontal space for `PATTERN` comment explanation, puts it under the `PATTERN`
  - Reduces vertical space of the `TEMPLATE` with `\n`

There's also some cosmetic changes to `generate.py`: the black-formatting escape we discussed and an extra comment.