### PR TITLE
Aligning Aritra-Documentation with docugen

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ python generate.py --help
 
 ### Requirements
 
-*  `pip install git+git://github.com/ariG23498/docs.git@wandb-docs` 
-
+* `git clone https://github.com/ariG23498/docugen.git`
+* `cd docugen`
+* `pip install .` 

--- a/docgen_lib.py
+++ b/docgen_lib.py
@@ -1,7 +1,7 @@
 import os
 
-from tensorflow_docs.api_generator import doc_controls
-from tensorflow_docs.api_generator import generate_lib
+from docugen import doc_controls
+from docugen import generate_lib
 import wandb
 
 DIRNAME = "library"

--- a/docgen_lib.py
+++ b/docgen_lib.py
@@ -52,9 +52,9 @@ def build_docs(name_pair, output_dir, code_url_prefix):
         py_modules=[name_pair],
         base_dir=os.path.dirname(wandb.__file__),
         code_url_prefix=code_url_prefix,
-        # gen_report=False,
         site_path="",
-        search_hints=False,
+        # gen_report=False,
+        # search_hints=False,
         yaml_toc=False,
     )
 

--- a/docgen_lib.py
+++ b/docgen_lib.py
@@ -52,9 +52,9 @@ def build_docs(name_pair, output_dir, code_url_prefix):
         py_modules=[name_pair],
         base_dir=os.path.dirname(wandb.__file__),
         code_url_prefix=code_url_prefix,
+        # gen_report=False,
         site_path="",
         search_hints=False,
-        gen_report=False,
         yaml_toc=False,
     )
 

--- a/docgen_lib.py
+++ b/docgen_lib.py
@@ -35,7 +35,7 @@ def build(git_hash, code_url_prefix, output_dir):
     build_api_docs(git_hash, code_url_prefix, output_dir)
 
 
-def build_docs(name_pair, output_dir, code_url_prefix, search_hints, gen_report):
+def build_docs(name_pair, output_dir, code_url_prefix):
     """Build api docs for W&B.
 
     Args:
@@ -51,10 +51,10 @@ def build_docs(name_pair, output_dir, code_url_prefix, search_hints, gen_report)
         root_title="W&B",
         py_modules=[name_pair],
         base_dir=os.path.dirname(wandb.__file__),
-        search_hints=search_hints,
         code_url_prefix=code_url_prefix,
         site_path="",
-        gen_report=gen_report,
+        search_hints=False,
+        gen_report=False,
         yaml_toc=False,
     )
 
@@ -96,8 +96,6 @@ def build_library_docs(git_hash, code_url_prefix, output_dir):
         name_pair=(DIRNAME, wandb),
         output_dir=output_dir,
         code_url_prefix=code_url_prefix,
-        search_hints=False,
-        gen_report=False,
     )
 
 
@@ -110,8 +108,6 @@ def build_datatype_docs(git_hash, code_url_prefix, output_dir):
         name_pair=("data-types", wandb),
         output_dir=os.path.join(output_dir, DIRNAME),
         code_url_prefix=code_url_prefix,
-        search_hints=False,
-        gen_report=False,
     )
 
 
@@ -148,8 +144,6 @@ def build_api_docs(git_hash, code_url_prefix, output_dir):
         name_pair=("public-api", wandb),
         output_dir=os.path.join(output_dir, DIRNAME),
         code_url_prefix=code_url_prefix,
-        search_hints=False,
-        gen_report=False,
     )
 
 

--- a/docgen_lib.py
+++ b/docgen_lib.py
@@ -55,7 +55,7 @@ def build_docs(name_pair, output_dir, code_url_prefix):
         site_path="",
         # gen_report=False,
         # search_hints=False,
-        yaml_toc=False,
+        # yaml_toc=False,
     )
 
     doc_generator.build(output_dir)

--- a/docgen_lib.py
+++ b/docgen_lib.py
@@ -53,9 +53,6 @@ def build_docs(name_pair, output_dir, code_url_prefix):
         base_dir=os.path.dirname(wandb.__file__),
         code_url_prefix=code_url_prefix,
         site_path="",
-        # gen_report=False,
-        # search_hints=False,
-        # yaml_toc=False,
     )
 
     doc_generator.build(output_dir)


### PR DESCRIPTION
In this PR:
1. Changed the imports from tf-docs to docugen
2. Removed some parameters from `docgen_lib.py` that were not required in `docugen`